### PR TITLE
Added support to print multiple labels at once

### DIFF
--- a/pdf2tspl.py
+++ b/pdf2tspl.py
@@ -59,6 +59,7 @@ def pdf2tspl(filename, labelwidth_mm=100, labelheight_mm=150, dpi=203.2):
     return tspl
 
 if __name__ == "__main__":
+    from PyPDF2 import PdfFileWriter, PdfFileReader
     import argparse
     import sys
     parser = argparse.ArgumentParser(description='Convert a PDF to TSPL to send to a label printer.')
@@ -70,13 +71,22 @@ if __name__ == "__main__":
     parser.add_argument('-d', '--dpi', type=float, default=203.2, help='Resolution of the printer. Defaults to 8 dots per mm (203.2 dpi)')
     args = parser.parse_args()
 
-    tspl = pdf2tspl(args.pdf_file,
-                    labelwidth_mm=args.width,
-                    labelheight_mm=args.height,
-                    dpi=args.dpi)
+    inputpdf = PdfFileReader(open(args.pdf_file, "rb"))
 
-    if args.tspl_file == '-':
-        sys.stdout.buffer.write(tspl)
-    else:
-        with open(args.tspl_file, 'wb') as fp:
-            fp.write(tspl)
+    for i in range(inputpdf.numPages):
+        output = PdfFileWriter()
+        output.addPage(inputpdf.getPage(i))
+        temp_pdf_name = "temp/document-page%s.pdf" % i
+        with open(temp_pdf_name, "wb") as outputStream:
+            output.write(outputStream)
+
+        tspl = pdf2tspl(temp_pdf_name,
+        labelwidth_mm=args.width,
+        labelheight_mm=args.height,
+        dpi=args.dpi)
+
+        if args.tspl_file == '-':
+            sys.stdout.buffer.write(tspl)
+        else:
+            with open(args.tspl_file, 'wb') as fp:
+                fp.write(tspl)

--- a/pdf2tspl.py
+++ b/pdf2tspl.py
@@ -43,7 +43,7 @@ def convert_pdf_scaled(pdfname, max_width, max_height):
 
     return im
 
-def pdf2tspl(filename, labelwidth_mm=100, labelheight_mm=150, dpi=203.2):
+def pdf2tspl(filename, labelwidth_mm=50, labelheight_mm=40, dpi=203.2):
     labelwidth = int(round(labelwidth_mm / 25.4 * dpi))
     labelheight = int(round(labelheight_mm / 25.4 * dpi))
 
@@ -59,23 +59,23 @@ def pdf2tspl(filename, labelwidth_mm=100, labelheight_mm=150, dpi=203.2):
     return tspl
 
 if __name__ == "__main__":
-    from PyPDF2 import PdfFileWriter, PdfFileReader
+    from PyPDF2 import PdfWriter, PdfReader
     import argparse
     import sys
     parser = argparse.ArgumentParser(description='Convert a PDF to TSPL to send to a label printer.')
     parser.add_argument('pdf_file', help='The PDF to convert.')
     parser.add_argument('tspl_file', help='The file or device to write the TSPL code to. Can be a printer device eg. /dev/usb/lp0, or specify "-" to write to stdout.')
 
-    parser.add_argument('-x', '--width', type=int, default=100, help='The width of the label, in millimetres.')
-    parser.add_argument('-y', '--height', type=int, default=150, help='The height of the label, in millimetres.')
+    parser.add_argument('-x', '--width', type=int, default=50, help='The width of the label, in millimetres.')
+    parser.add_argument('-y', '--height', type=int, default=40, help='The height of the label, in millimetres.')
     parser.add_argument('-d', '--dpi', type=float, default=203.2, help='Resolution of the printer. Defaults to 8 dots per mm (203.2 dpi)')
     args = parser.parse_args()
 
-    inputpdf = PdfFileReader(open(args.pdf_file, "rb"))
+    inputpdf = PdfReader(open(args.pdf_file, "rb"))
 
-    for i in range(inputpdf.numPages):
-        output = PdfFileWriter()
-        output.addPage(inputpdf.getPage(i))
+    for i in range(len(inputpdf.pages)):
+        output = PdfWriter()
+        output.add_page(inputpdf.pages[i])
         temp_pdf_name = "temp/document-page%s.pdf" % i
         with open(temp_pdf_name, "wb") as outputStream:
             output.write(outputStream)


### PR DESCRIPTION
The PDF file will be broken into multiple files and printed one by one, with no effect on the printing speed when testing, stable.